### PR TITLE
Swallow TaskCanceledExceptions because they're exceedingly common

### DIFF
--- a/Ags.ResourceProxy.Core/Proxy/ProxyServerMiddleware.cs
+++ b/Ags.ResourceProxy.Core/Proxy/ProxyServerMiddleware.cs
@@ -130,8 +130,16 @@ namespace Ags.ResourceProxy.Core {
 			// Removes the header so it doesn't expect a chunked response.
 			response.Headers.Remove("transfer-encoding");
 
-			using (var responseStream = await responseMessage.Content.ReadAsStreamAsync()) {
-				await responseStream.CopyToAsync(response.Body, context.RequestAborted);
+			try
+			{
+				using (var responseStream = await responseMessage.Content.ReadAsStreamAsync())
+				{
+					await responseStream.CopyToAsync(response.Body, context.RequestAborted);
+				}
+			}
+			catch (TaskCanceledException)
+			{
+				//no-op: task cancelations are incredibly common and flood app-level logging
 			}
 		}
 


### PR DESCRIPTION
We were noticing that any time the user performed actions quickly, our application-level logging was getting flooded with TaskCanceledExceptions, and so figured that just swallowing them within the package might be helpful to others as well.

Thanks!